### PR TITLE
🐛 - fix shouldComponentUpdate

### DIFF
--- a/src/components/tile/index.js
+++ b/src/components/tile/index.js
@@ -111,7 +111,10 @@ function handleClick(props, event) {
 }
 
 export function shouldUpdate(lastProps, nextProps) {
-  return lastProps.value !== nextProps.value;
+  return (
+    lastProps.value !== nextProps.value ||
+    lastProps.game !== nextProps.game
+  );
 }
 
 export default function Tile(props) {


### PR DESCRIPTION
Check for change in game state to allow unswept mines to update.  Closes #41 