### PR TITLE
🔒 - auth with env token when aliasing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ deployment:
   production:
     branch: master
     commands:
-      - now -t ${NOW_TOKEN} && now alias
+      - now -t ${NOW_TOKEN} && now -t ${NOW_TOKEN} alias
   dev:
     branch: staging
     commands:


### PR DESCRIPTION
Need to provide `NOW_TOKEN` to alias command to keep `now` from prompting email input in Circle and suspending the build.